### PR TITLE
Paving the way to plug this into a CI environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+results.xml

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ gem 'rake'
 gem 'rspec'
 gem 'page-object'
 gem 'require_all'
-
+gem 'rspec-extra-formatters'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,32 +1,37 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    childprocess (0.3.1)
+    addressable (2.2.8)
+    childprocess (0.3.2)
       ffi (~> 1.0.6)
     diff-lcs (1.1.3)
     ffi (1.0.11)
-    multi_json (1.1.0)
-    page-object (0.6.3)
-      selenium-webdriver (>= 2.20.0)
-      watir-webdriver (>= 0.5.3)
+    libwebsocket (0.1.3)
+      addressable
+    multi_json (1.3.6)
+    page-object (0.6.8)
+      selenium-webdriver (>= 2.22.1)
+      watir-webdriver (>= 0.6.1)
     rake (0.9.2.2)
     require_all (1.2.1)
-    rspec (2.8.0)
-      rspec-core (~> 2.8.0)
-      rspec-expectations (~> 2.8.0)
-      rspec-mocks (~> 2.8.0)
-    rspec-core (2.8.0)
-    rspec-expectations (2.8.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.8.0)
-    rubyzip (0.9.6.1)
-    selenium-webdriver (2.20.0)
+    rspec (2.10.0)
+      rspec-core (~> 2.10.0)
+      rspec-expectations (~> 2.10.0)
+      rspec-mocks (~> 2.10.0)
+    rspec-core (2.10.1)
+    rspec-expectations (2.10.0)
+      diff-lcs (~> 1.1.3)
+    rspec-extra-formatters (0.4)
+    rspec-mocks (2.10.1)
+    rubyzip (0.9.8)
+    selenium-webdriver (2.22.1)
       childprocess (>= 0.2.5)
       ffi (~> 1.0)
+      libwebsocket (~> 0.1.3)
       multi_json (~> 1.0)
       rubyzip
-    watir-webdriver (0.5.3)
-      selenium-webdriver (>= 2.12.0)
+    watir-webdriver (0.6.1)
+      selenium-webdriver (>= 2.18.0)
 
 PLATFORMS
   ruby
@@ -37,3 +42,4 @@ DEPENDENCIES
   rake
   require_all
   rspec
+  rspec-extra-formatters

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.ruby_opts = "-I lib:spec"
   spec.pattern = 'spec/**/*_spec.rb'
+  spec.rspec_opts = ["-r rspec-extra-formatters", "-f JUnitFormatter", '-o results.xml']
 end
 
 RSpec::Core::RakeTask.new(:login_spec) do |spec|


### PR DESCRIPTION
This pull request bumps the current gem versions and adds a new dependency (rspec-extra-formatters) to make the suite Jenkins/CI friendly.

Maybe I should have made separate commits, but there shouldn't be any major problems.
